### PR TITLE
Use a `ManuallyDrop` instead of an `Option` for dropping the guard

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,42 +103,42 @@ pub struct RcMutexGuardian<T: 'static> {
 impl<T> Deref for ArcRwLockReadGuardian<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
-        &self.inner
+        self.inner.deref()
     }
 }
 
 impl<T> Deref for ArcRwLockWriteGuardian<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
-        &self.inner
+        self.inner.deref()
     }
 }
 
 impl<T> Deref for ArcMutexGuardian<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
-        &self.inner
+        self.inner.deref()
     }
 }
 
 impl<T> Deref for RcRwLockReadGuardian<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
-        &self.inner
+        self.inner.deref()
     }
 }
 
 impl<T> Deref for RcRwLockWriteGuardian<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
-        &self.inner
+        self.inner.deref()
     }
 }
 
 impl<T> Deref for RcMutexGuardian<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
-        &self.inner
+        self.inner.deref()
     }
 }
 
@@ -148,25 +148,25 @@ impl<T> Deref for RcMutexGuardian<T> {
 
 impl<T> DerefMut for ArcRwLockWriteGuardian<T> {
     fn deref_mut(&mut self) -> &mut T {
-        &mut self.inner
+        self.inner.deref_mut()
     }
 }
 
 impl<T> DerefMut for RcRwLockWriteGuardian<T> {
     fn deref_mut(&mut self) -> &mut T {
-        &mut self.inner
+        self.inner.deref_mut()
     }
 }
 
 impl<T> DerefMut for ArcMutexGuardian<T> {
     fn deref_mut(&mut self) -> &mut T {
-        &mut self.inner
+        self.inner.deref_mut()
     }
 }
 
 impl<T> DerefMut for RcMutexGuardian<T> {
     fn deref_mut(&mut self) -> &mut T {
-        &mut self.inner
+        self.inner.deref_mut()
     }
 }
 
@@ -527,7 +527,7 @@ impl<T> RcMutexGuardian<T> {
 impl<T> Drop for ArcRwLockReadGuardian<T> {
     fn drop(&mut self) {
         // Rust Drop glue don't specify the drop order of a struct fields,
-        // but because the guard access the handle during it's drop we need to ensure
+        // but because the guard access the handle during its drop, we need to ensure
         // that it is dropped *before* the handle.
         // For that we wrap it in a `ManuallyDrop` and drop it ourselves before the drop glue.
         // It is safe to drop it here as it will never be accessed again.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@
 //! result may be poisoned on panics. The poison is propagated from that of the underlying `lock()`
 //! method, so for `RwLock`s, the same rule applies for when a lock may be poisioned.
 
+use std::mem::ManuallyDrop;
 use std::ops::Deref;
 use std::ops::DerefMut;
 use std::rc;
@@ -26,7 +27,7 @@ use std::sync;
 // RwLock. If you change anything for one type, be sure to also make the same changes to the other
 // variants below.
 //
-// Each structure holds the guard in an Option to ensure that we drop the guard before we drop the
+// Each structure holds the guard in an `ManuallyDrop` to ensure that we drop the guard before we drop the
 // handle, as dropping the guard will access the handle.
 
 // ****************************************************************************
@@ -40,7 +41,7 @@ use std::sync;
 /// implementations.
 pub struct ArcRwLockReadGuardian<T: 'static> {
     _handle: sync::Arc<sync::RwLock<T>>,
-    inner: Option<sync::RwLockReadGuard<'static, T>>,
+    inner: ManuallyDrop<sync::RwLockReadGuard<'static, T>>,
 }
 
 /// RAII structure used to release the exclusive write access of a lock when dropped.
@@ -50,7 +51,7 @@ pub struct ArcRwLockReadGuardian<T: 'static> {
 /// implementations.
 pub struct ArcRwLockWriteGuardian<T: 'static> {
     _handle: sync::Arc<sync::RwLock<T>>,
-    inner: Option<sync::RwLockWriteGuard<'static, T>>,
+    inner: ManuallyDrop<sync::RwLockWriteGuard<'static, T>>,
 }
 
 /// An RAII implementation of a "scoped lock" of a mutex. When this structure is dropped (falls out
@@ -61,7 +62,7 @@ pub struct ArcRwLockWriteGuardian<T: 'static> {
 /// implementations.
 pub struct ArcMutexGuardian<T: 'static> {
     _handle: sync::Arc<sync::Mutex<T>>,
-    inner: Option<sync::MutexGuard<'static, T>>,
+    inner: ManuallyDrop<sync::MutexGuard<'static, T>>,
 }
 
 /// RAII structure used to release the shared read access of a lock when dropped.
@@ -71,7 +72,7 @@ pub struct ArcMutexGuardian<T: 'static> {
 /// implementations.
 pub struct RcRwLockReadGuardian<T: 'static> {
     _handle: rc::Rc<sync::RwLock<T>>,
-    inner: Option<sync::RwLockReadGuard<'static, T>>,
+    inner: ManuallyDrop<sync::RwLockReadGuard<'static, T>>,
 }
 
 /// RAII structure used to release the exclusive write access of a lock when dropped.
@@ -81,7 +82,7 @@ pub struct RcRwLockReadGuardian<T: 'static> {
 /// implementations.
 pub struct RcRwLockWriteGuardian<T: 'static> {
     _handle: rc::Rc<sync::RwLock<T>>,
-    inner: Option<sync::RwLockWriteGuard<'static, T>>,
+    inner: ManuallyDrop<sync::RwLockWriteGuard<'static, T>>,
 }
 
 /// An RAII implementation of a "scoped lock" of a mutex. When this structure is dropped (falls out
@@ -92,7 +93,7 @@ pub struct RcRwLockWriteGuardian<T: 'static> {
 /// implementations.
 pub struct RcMutexGuardian<T: 'static> {
     _handle: rc::Rc<sync::Mutex<T>>,
-    inner: Option<sync::MutexGuard<'static, T>>,
+    inner: ManuallyDrop<sync::MutexGuard<'static, T>>,
 }
 
 // ****************************************************************************
@@ -102,42 +103,42 @@ pub struct RcMutexGuardian<T: 'static> {
 impl<T> Deref for ArcRwLockReadGuardian<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
-        self.inner.as_ref().expect("inner is None only in drop")
+        &self.inner
     }
 }
 
 impl<T> Deref for ArcRwLockWriteGuardian<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
-        self.inner.as_ref().expect("inner is None only in drop")
+        &self.inner
     }
 }
 
 impl<T> Deref for ArcMutexGuardian<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
-        self.inner.as_ref().expect("inner is None only in drop")
+        &self.inner
     }
 }
 
 impl<T> Deref for RcRwLockReadGuardian<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
-        self.inner.as_ref().expect("inner is None only in drop")
+        &self.inner
     }
 }
 
 impl<T> Deref for RcRwLockWriteGuardian<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
-        self.inner.as_ref().expect("inner is None only in drop")
+        &self.inner
     }
 }
 
 impl<T> Deref for RcMutexGuardian<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
-        self.inner.as_ref().expect("inner is None only in drop")
+        &self.inner
     }
 }
 
@@ -147,25 +148,25 @@ impl<T> Deref for RcMutexGuardian<T> {
 
 impl<T> DerefMut for ArcRwLockWriteGuardian<T> {
     fn deref_mut(&mut self) -> &mut T {
-        self.inner.as_mut().expect("inner is None only in drop")
+        &mut self.inner
     }
 }
 
 impl<T> DerefMut for RcRwLockWriteGuardian<T> {
     fn deref_mut(&mut self) -> &mut T {
-        self.inner.as_mut().expect("inner is None only in drop")
+        &mut self.inner
     }
 }
 
 impl<T> DerefMut for ArcMutexGuardian<T> {
     fn deref_mut(&mut self) -> &mut T {
-        self.inner.as_mut().expect("inner is None only in drop")
+        &mut self.inner
     }
 }
 
 impl<T> DerefMut for RcMutexGuardian<T> {
     fn deref_mut(&mut self) -> &mut T {
-        self.inner.as_mut().expect("inner is None only in drop")
+        &mut self.inner
     }
 }
 
@@ -227,11 +228,11 @@ macro_rules! take {
         match lock {
             Ok(guard) => Ok($guardian {
                 _handle: $handle,
-                inner: Some(guard),
+                inner: ManuallyDrop::new(guard),
             }),
             Err(guard) => Err(sync::PoisonError::new($guardian {
                 _handle: $handle,
-                inner: Some(guard.into_inner()),
+                inner: ManuallyDrop::new(guard.into_inner()),
             })),
         }
     }};
@@ -248,12 +249,12 @@ macro_rules! try_take {
         match lock {
             Ok(guard) => Some(Ok($guardian {
                 _handle: $handle,
-                inner: Some(guard),
+                inner: ManuallyDrop::new(guard),
             })),
             Err(WouldBlock) => None,
             Err(Poisoned(guard)) => Some(Err(sync::PoisonError::new($guardian {
                 _handle: $handle,
-                inner: Some(guard.into_inner()),
+                inner: ManuallyDrop::new(guard.into_inner()),
             }))),
         }
     }};
@@ -525,37 +526,59 @@ impl<T> RcMutexGuardian<T> {
 
 impl<T> Drop for ArcRwLockReadGuardian<T> {
     fn drop(&mut self) {
-        self.inner.take();
+        // Rust Drop glue don't specify the drop order of a struct fields,
+        // but because the guard access the handle during it's drop we need to ensure
+        // that it is dropped *before* the handle.
+        // For that we wrap it in a `ManuallyDrop` and drop it ourselves before the drop glue.
+        // It is safe to drop it here as it will never be accessed again.
+        unsafe {
+            ManuallyDrop::drop(&mut self.inner);
+        }
     }
 }
 
 impl<T> Drop for ArcRwLockWriteGuardian<T> {
     fn drop(&mut self) {
-        self.inner.take();
+        // Safety: Same reasons as `ArcRwLockGuardian`
+        unsafe {
+            ManuallyDrop::drop(&mut self.inner);
+        }
     }
 }
 
 impl<T> Drop for ArcMutexGuardian<T> {
     fn drop(&mut self) {
-        self.inner.take();
+        // Safety: Same reasons as `ArcRwLockGuardian`
+        unsafe {
+            ManuallyDrop::drop(&mut self.inner);
+        }
     }
 }
 
 impl<T> Drop for RcRwLockReadGuardian<T> {
     fn drop(&mut self) {
-        self.inner.take();
+        // Safety: Same reasons as `ArcRwLockGuardian`
+        unsafe {
+            ManuallyDrop::drop(&mut self.inner);
+        }
     }
 }
 
 impl<T> Drop for RcRwLockWriteGuardian<T> {
     fn drop(&mut self) {
-        self.inner.take();
+        // Safety: Same reasons as `ArcRwLockGuardian`
+        unsafe {
+            ManuallyDrop::drop(&mut self.inner);
+        }
     }
 }
 
 impl<T> Drop for RcMutexGuardian<T> {
     fn drop(&mut self) {
-        self.inner.take();
+        // Safety: Same reasons as `ArcRwLockGuardian`
+        unsafe {
+            ManuallyDrop::drop(&mut self.inner);
+        }
     }
 }
 


### PR DESCRIPTION
This is a follow up to #2, ensuring drop order was a really great catch, but the use of an `Option` introduce the need for `Option::expect` at every access points, this is an unecessary branching and introduce possible unwinding to places it should'nt need to, as it already is an invariant that the `Option` should not be empty until Drop.

This PR replace the use of an `Option` by `ManuallyDrop`, this let us have a clean `Deref/Mut` impl and still control the Drop order.

Sadly this does introduce an new `unsafe` section in the Drop impls, but it is contained at the end of life of the guard, and does not spread into the guard lifetime, making it an easy to inforce invariant.